### PR TITLE
DAT-21 Implement match

### DIFF
--- a/internal/app/api/api.go
+++ b/internal/app/api/api.go
@@ -106,7 +106,7 @@ func Init(conns *config.Configs, em config.ErrorMessage) (http.Handler, error) {
 			handler:     userHandler.GetListUsers,
 		},
 		route{
-			path:        "/users/match",
+			path:        "/users/matchs",
 			method:      put,
 			middlewares: []middlewareFunc{middleware.Auth},
 			handler:     matchHandler.InsertMatches,

--- a/internal/app/api/api.go
+++ b/internal/app/api/api.go
@@ -6,8 +6,12 @@ import (
 	userhandler "dating/internal/app/api/handler/user"
 	user "dating/internal/app/api/repositories/user"
 	userService "dating/internal/app/api/services/user"
-	"dating/internal/app/config"
 
+	matchhandler "dating/internal/app/api/handler/match"
+	match "dating/internal/app/api/repositories/match"
+	matchService "dating/internal/app/api/services/match"
+
+	"dating/internal/app/config"
 	"dating/internal/app/db"
 	"dating/internal/pkg/glog"
 	"dating/internal/pkg/health"
@@ -44,6 +48,7 @@ func Init(conns *config.Configs, em config.ErrorMessage) (http.Handler, error) {
 	logger := glog.New()
 
 	var userRepo userService.Repository
+	var matchRepo matchService.Repository
 	switch conns.Database.Type {
 	case db.TypeMongoDB:
 		s, err := config.Dial(&conns.Database.Mongo, logger)
@@ -51,6 +56,7 @@ func Init(conns *config.Configs, em config.ErrorMessage) (http.Handler, error) {
 			logger.Panicf("failed to dial to target server, err: %v", err)
 		}
 		userRepo = user.NewMongoRepository(s)
+		matchRepo = match.NewMongoRepository(s)
 	default:
 		panic("database type not supported: " + conns.Database.Type)
 	}
@@ -58,6 +64,10 @@ func Init(conns *config.Configs, em config.ErrorMessage) (http.Handler, error) {
 	userLogger := logger.WithField("package", "user")
 	userSrv := userService.NewService(conns, &em, userRepo, userLogger)
 	userHandler := userhandler.New(conns, &em, userSrv, userLogger)
+
+	matchLogger := logger.WithField("package", "match")
+	matchSrv := matchService.NewService(conns, &em, matchRepo, matchLogger)
+	matchHandler := matchhandler.New(conns, &em, matchSrv, matchLogger)
 
 	routes := []route{
 		// infra
@@ -94,6 +104,12 @@ func Init(conns *config.Configs, em config.ErrorMessage) (http.Handler, error) {
 			method:      get,
 			middlewares: []middlewareFunc{middleware.Auth},
 			handler:     userHandler.GetListUsers,
+		},
+		route{
+			path:        "/users/match",
+			method:      put,
+			middlewares: []middlewareFunc{middleware.Auth},
+			handler:     matchHandler.InsertMatches,
 		},
 	}
 

--- a/internal/app/api/handler/match/match.go
+++ b/internal/app/api/handler/match/match.go
@@ -1,0 +1,66 @@
+package userhandler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"dating/internal/app/api/types"
+	"dating/internal/app/config"
+	"dating/internal/pkg/glog"
+	"dating/internal/pkg/respond"
+
+	"github.com/go-playground/validator/v10"
+)
+
+type (
+	service interface {
+		InsertMatches(ctx context.Context, Match types.MatchRequest) (*types.Match, error)
+	}
+	// Handler is user web handler
+	Handler struct {
+		conf   *config.Configs
+		em     *config.ErrorMessage
+		srv    service
+		logger glog.Logger
+	}
+)
+
+var (
+	validate = validator.New()
+)
+
+// New returns new res api user handler
+func New(c *config.Configs, e *config.ErrorMessage, s service, l glog.Logger) *Handler {
+	return &Handler{
+		conf:   c,
+		em:     e,
+		srv:    s,
+		logger: l,
+	}
+}
+
+// Post handler  post sign up HTTP request
+func (h *Handler) InsertMatches(w http.ResponseWriter, r *http.Request) {
+
+	var matchRequest types.MatchRequest
+
+	if err := json.NewDecoder(r.Body).Decode(&matchRequest); err != nil {
+		respond.JSON(w, http.StatusBadRequest, h.em.InvalidValue.ValidationFailed)
+		return
+	}
+
+	if err := validate.Struct(matchRequest); err != nil {
+		h.logger.Errorf("Failed when validate field matchRequest", err)
+		respond.JSON(w, http.StatusBadRequest, h.em.InvalidValue.ValidationFailed)
+		return
+	}
+
+	match, err := h.srv.InsertMatches(r.Context(), matchRequest)
+	if err != nil {
+		respond.JSON(w, http.StatusBadRequest, h.em.InvalidValue.Request)
+		return
+	}
+
+	respond.JSON(w, http.StatusOK, match)
+}

--- a/internal/app/api/repositories/match/match_repo.go
+++ b/internal/app/api/repositories/match/match_repo.go
@@ -1,0 +1,150 @@
+package match
+
+import (
+	"context"
+
+	"dating/internal/app/api/types"
+
+	mgo "github.com/globalsign/mgo"
+	"github.com/globalsign/mgo/bson"
+	"github.com/pkg/errors"
+)
+
+var (
+	ErrNotFound = errors.New("not found")
+)
+
+type MongoRepository struct {
+	session *mgo.Session
+}
+
+func NewMongoRepository(s *mgo.Session) *MongoRepository {
+	return &MongoRepository{
+		session: s,
+	}
+}
+
+// this method helps insert match
+func (r *MongoRepository) Insert(ctx context.Context, match types.Match) error {
+	s := r.session.Clone()
+	defer s.Close()
+
+	err := r.collection(s).Insert(match)
+
+	return err
+}
+
+// this method helps insert match
+func (r *MongoRepository) DeleteMatch(ctx context.Context, match types.Match) error {
+	s := r.session.Clone()
+	defer s.Close()
+
+	err := r.collection(s).RemoveId(match.ID)
+
+	return err
+}
+
+// This method helps get basic info match by id
+func (r *MongoRepository) FindByID(ctx context.Context, id string) (*types.Match, error) {
+	s := r.session.Clone()
+	defer s.Close()
+
+	var match *types.Match
+	err := r.collection(s).FindId(bson.ObjectIdHex(id)).One(&match)
+
+	return match, err
+}
+
+// this method help get record when user A like user B
+func (r *MongoRepository) FindALikeB(ctx context.Context, idUser, idTargetUser string) (*types.Match, error) {
+	s := r.session.Clone()
+	defer s.Close()
+
+	filter := bson.M{
+		"user_id":        bson.ObjectIdHex(idUser),
+		"target_user_id": bson.ObjectIdHex(idTargetUser),
+	}
+
+	var match *types.Match
+	err := r.collection(s).Find(filter).One(&match)
+
+	return match, err
+}
+
+// this method help get update match true when A,B liked
+func (r *MongoRepository) UpdateMatchByID(ctx context.Context, id string) error {
+	s := r.session.Clone()
+	defer s.Close()
+
+	updatedUser := bson.M{"$set": bson.M{"match": true}}
+	err := r.collection(s).UpdateId(bson.ObjectIdHex(id), updatedUser)
+
+	return err
+}
+
+// this method help get list like
+func (r *MongoRepository) GetListLiked(ctx context.Context, idUser string) ([]*types.Match, error) {
+	s := r.session.Clone()
+	defer s.Close()
+
+	filter := bson.M{
+		"user_id": bson.ObjectIdHex(idUser),
+		"match":   false,
+	}
+	var match []*types.Match
+	err := r.collection(s).Find(filter).All(&match)
+
+	return match, err
+}
+
+// this method help get list matched
+func (r *MongoRepository) GetListMatched(ctx context.Context, idUser string) ([]*types.Match, error) {
+	s := r.session.Clone()
+	defer s.Close()
+
+	filter := bson.M{
+		"$or": []interface{}{
+			bson.M{"user_id": bson.ObjectIdHex(idUser)},
+			bson.M{"target_user_id": bson.ObjectIdHex(idUser)},
+		},
+		"match": true,
+	}
+	var match []*types.Match
+	err := r.collection(s).Find(filter).All(&match)
+
+	return match, err
+}
+
+// this method help get list matched include info
+func (r *MongoRepository) GetListMatchedInfo(ctx context.Context, idUser string) ([]*types.MatchResponse, error) {
+	s := r.session.Clone()
+	defer s.Close()
+
+	filter := bson.M{
+		"$or": []interface{}{
+			bson.M{"user_id": bson.ObjectIdHex(idUser)},
+			bson.M{"target_user_id": bson.ObjectIdHex(idUser)},
+		},
+		"match": true,
+	}
+
+	query := []bson.M{
+		{"$match": filter},
+		{"$lookup": bson.M{
+			"from":         "users",
+			"localField":   "target_user_id",
+			"foreignField": "_id",
+			"as":           "target_user",
+		}},
+	}
+
+	var listMatched []*types.MatchResponse
+
+	err := r.collection(s).Pipe(query).All(&listMatched)
+
+	return listMatched, err
+}
+
+func (r *MongoRepository) collection(s *mgo.Session) *mgo.Collection {
+	return s.DB("").C("matches")
+}

--- a/internal/app/api/repositories/user/user_repo.go
+++ b/internal/app/api/repositories/user/user_repo.go
@@ -73,8 +73,6 @@ func (r *MongoRepository) UpdateUserByID(ctx context.Context, user types.User) e
 		"hobby":        user.Hobby,
 		"sex":          user.Sex,
 		"about":        user.About,
-		"like_id":      user.LikeID,
-		"match_id":     user.MatchID,
 		"updated_at":   time.Now(),
 	}}
 	err := r.collection(s).UpdateId(user.ID, updatedUser)

--- a/internal/app/api/services/match/match.go
+++ b/internal/app/api/services/match/match.go
@@ -1,0 +1,98 @@
+package matchservices
+
+import (
+	"context"
+	"time"
+
+	"dating/internal/app/api/types"
+	"dating/internal/app/config"
+	"dating/internal/pkg/glog"
+
+	"github.com/globalsign/mgo/bson"
+	"github.com/pkg/errors"
+)
+
+// Repository is an interface of a user repository
+type Repository interface {
+	Insert(ctx context.Context, Match types.Match) error
+	FindByID(ctx context.Context, id string) (*types.Match, error)
+	FindALikeB(ctx context.Context, idUser, idTargetUser string) (*types.Match, error)
+	UpdateMatchByID(ctx context.Context, id string) error
+	GetListLiked(ctx context.Context, idUser string) ([]*types.Match, error)
+	GetListMatched(ctx context.Context, idUser string) ([]*types.Match, error)
+	DeleteMatch(ctx context.Context, match types.Match) error
+}
+
+// Service is an user service
+type Service struct {
+	conf   *config.Configs
+	em     *config.ErrorMessage
+	repo   Repository
+	logger glog.Logger
+}
+
+// NewService returns a new user service
+func NewService(c *config.Configs, e *config.ErrorMessage, r Repository, l glog.Logger) *Service {
+	return &Service{
+		conf:   c,
+		em:     e,
+		repo:   r,
+		logger: l,
+	}
+}
+
+// Post basic info user for sign up > A like B
+func (s *Service) InsertMatches(ctx context.Context, matchreq types.MatchRequest) (*types.Match, error) {
+
+	// check user B like user A
+	matchcheckBA, err := s.repo.FindALikeB(ctx, matchreq.TargetUserID.Hex(), matchreq.UserID.Hex())
+
+	if err != nil {
+		// check user A like user B
+		matchcheckAB, err := s.repo.FindALikeB(ctx, matchreq.UserID.Hex(), matchreq.TargetUserID.Hex())
+		if err != nil {
+			match := types.Match{
+				ID:           bson.NewObjectId(),
+				UserID:       matchreq.UserID,
+				TargetUserID: matchreq.TargetUserID,
+				Match:        false,
+				CreateAt:     time.Now(),
+			}
+			if err := s.repo.Insert(ctx, match); err != nil {
+				s.logger.Errorf("Can't insert user", err)
+				return nil, errors.Wrap(err, "Can't insert user")
+			}
+
+			matchfind, err := s.repo.FindByID(ctx, match.ID.Hex())
+			if err != nil {
+				s.logger.Errorf("Can't insert match", err)
+				return nil, errors.Wrap(err, "Can't insert match")
+			}
+			s.logger.Infof("Liked completed", matchreq)
+			return matchfind, nil
+		}
+
+		// A liked B
+		s.logger.Infof("A liked B before", matchreq)
+		return matchcheckAB, nil
+	}
+	// B liked A
+	if matchcheckBA.Match {
+		s.logger.Infof("B, A matched before", matchreq)
+		return matchcheckBA, nil
+	}
+	if err := s.repo.UpdateMatchByID(ctx, matchcheckBA.ID.Hex()); err != nil {
+		s.logger.Errorf("Can't update match", err)
+		return nil, errors.Wrap(err, "Can't update match")
+	}
+
+	matchfind, err := s.repo.FindByID(ctx, matchcheckBA.ID.Hex())
+	if err != nil {
+		s.logger.Errorf("Can't find match", err)
+		return nil, errors.Wrap(err, "Can't find match")
+	}
+
+	s.logger.Infof("Match completed", matchreq)
+	return matchfind, nil
+
+}

--- a/internal/app/api/types/match.go
+++ b/internal/app/api/types/match.go
@@ -1,0 +1,29 @@
+package types
+
+import (
+	"time"
+
+	"github.com/globalsign/mgo/bson"
+)
+
+type Match struct {
+	ID           bson.ObjectId `json:"_id" bson:"_id,omitempty"`
+	UserID       bson.ObjectId `json:"user_id" bson:"user_id"`
+	TargetUserID bson.ObjectId `json:"target_user_id" bson:"target_user_id"`
+	Match        bool          `json:"match" bson:"match"`
+	CreateAt     time.Time     `json:"created_at" bson:"created_at"`
+}
+
+type MatchRequest struct {
+	UserID       bson.ObjectId `json:"user_id" bson:"user_id" validate:"required"`
+	TargetUserID bson.ObjectId `json:"target_user_id" bson:"target_user_id" validate:"required"`
+}
+
+type MatchResponse struct {
+	ID           bson.ObjectId    `json:"_id" bson:"_id,omitempty"`
+	UserID       bson.ObjectId    `json:"user_id" bson:"user_id"`
+	TargetUserID bson.ObjectId    `json:"target_user_id" bson:"target_user_id"`
+	Match        bool             `json:"match" bson:"match"`
+	CreateAt     time.Time        `json:"created_at" bson:"created_at"`
+	TargetUser   []UserResGetInfo `json:"target_user" bson:"target_user"`
+}

--- a/internal/app/api/types/user.go
+++ b/internal/app/api/types/user.go
@@ -7,42 +7,38 @@ import (
 )
 
 type User struct {
-	ID           bson.ObjectId   `json:"_id" bson:"_id,omitempty" validate:"required"`
-	Name         string          `json:"name" bson:"name" validate:"required"`
-	Email        string          `json:"email" bson:"email" validate:"omitempty,email"`
-	Birthday     time.Time       `json:"birthday" bson:"birthday" validate:"required"`
-	Relationship string          `json:"relationship" bson:"relationship" validate:"omitempty,max=60" `
-	LookingFor   string          `json:"looking_for" bson:"looking_for" validate:"omitempty,max=60"`
-	Password     string          `json:"password" bson:"password"`
-	Media        []string        `json:"media" bson:"media"` // arr path media
-	Gender       string          `json:"gender" bson:"gender" validate:"required"`
-	Sex          string          `json:"sex" bson:"sex" validate:"omitempty,max=60"`
-	Country      string          `json:"country" bson:"country" validate:"required,max=60"`
-	Hobby        []string        `json:"hobby" bson:"hobby"`
-	About        string          `json:"about" bson:"about" validate:"omitempty,max=256"`
-	LikeID       []bson.ObjectId `json:"like_id" bson:"like_id"`
-	MatchID      []bson.ObjectId `json:"match_id" bson:"match_id"`
-	CreateAt     time.Time       `json:"created_at" bson:"created_at"`
-	UpdateAt     time.Time       `json:"updated_at" bson:"updated_at"`
+	ID           bson.ObjectId `json:"_id" bson:"_id,omitempty" validate:"required"`
+	Name         string        `json:"name" bson:"name" validate:"required"`
+	Email        string        `json:"email" bson:"email" validate:"omitempty,email"`
+	Birthday     time.Time     `json:"birthday" bson:"birthday" validate:"required"`
+	Relationship string        `json:"relationship" bson:"relationship" validate:"omitempty,max=60" `
+	LookingFor   string        `json:"looking_for" bson:"looking_for" validate:"omitempty,max=60"`
+	Password     string        `json:"password" bson:"password"`
+	Media        []string      `json:"media" bson:"media"` // arr path media
+	Gender       string        `json:"gender" bson:"gender" validate:"required,max=60"`
+	Sex          string        `json:"sex" bson:"sex" validate:"omitempty,max=60"`
+	Country      string        `json:"country" bson:"country" validate:"required,max=60"`
+	Hobby        []string      `json:"hobby" bson:"hobby"`
+	About        string        `json:"about" bson:"about" validate:"omitempty,max=256"`
+	CreateAt     time.Time     `json:"created_at" bson:"created_at"`
+	UpdateAt     time.Time     `json:"updated_at" bson:"updated_at"`
 }
 
 type UserResGetInfo struct {
-	ID           bson.ObjectId   `json:"_id" bson:"_id,omitempty"`
-	Name         string          `json:"name" bson:"name" validate:"omitempty,max=60"`
-	Email        string          `json:"email" bson:"email"`
-	Birthday     time.Time       `json:"birthday" bson:"birthday"`
-	Relationship string          `json:"relationship" bson:"relationship" validate:"omitempty,max=60"`
-	LookingFor   string          `json:"looking_for" bson:"looking_for" validate:"omitempty,max=60"`
-	Media        []string        `json:"media" bson:"media"` // arr path media
-	Gender       string          `json:"gender" bson:"gender" validate:"omitempty,max=60"`
-	Sex          string          `json:"sex" bson:"sex" validate:"omitempty,max=60"`
-	Country      string          `json:"country" bson:"country" validate:"omitempty,max=60"`
-	Hobby        []string        `json:"hobby" bson:"hobby"`
-	About        string          `json:"about" bson:"about" validate:"omitempty,max=256"`
-	LikeID       []bson.ObjectId `json:"like_id" bson:"like_id"`
-	MatchID      []bson.ObjectId `json:"match_id" bson:"match_id"`
-	CreateAt     time.Time       `json:"created_at" bson:"created_at"`
-	UpdateAt     time.Time       `json:"updated_at" bson:"updated_at"`
+	ID           bson.ObjectId `json:"_id" bson:"_id,omitempty"`
+	Name         string        `json:"name" bson:"name" validate:"omitempty,max=60"`
+	Email        string        `json:"email" bson:"email"`
+	Birthday     time.Time     `json:"birthday" bson:"birthday"`
+	Relationship string        `json:"relationship" bson:"relationship" validate:"omitempty,max=60"`
+	LookingFor   string        `json:"looking_for" bson:"looking_for" validate:"omitempty,max=60"`
+	Media        []string      `json:"media" bson:"media"` // arr path media
+	Gender       string        `json:"gender" bson:"gender" validate:"omitempty,max=60"`
+	Sex          string        `json:"sex" bson:"sex" validate:"omitempty,max=60"`
+	Country      string        `json:"country" bson:"country" validate:"omitempty,max=60"`
+	Hobby        []string      `json:"hobby" bson:"hobby"`
+	About        string        `json:"about" bson:"about" validate:"omitempty,max=256"`
+	CreateAt     time.Time     `json:"created_at" bson:"created_at"`
+	UpdateAt     time.Time     `json:"updated_at" bson:"updated_at"`
 }
 
 type UserSignUp struct {


### PR DESCRIPTION
###  Implement match
API: /users/match Required token in the header
Structure of the body:
```
{
    "user_id": "60e3f9a7e1ab4c3dfc8fe4c1",
    "target_user_id": "60e3b5dbe1ab4c388ce2d04c"
}
```
Structure of the result:
```
{
    "_id": "",
    "user_id": "60e3f9a7e1ab4c3dfc8fe4c1",
    "target_user_id": "60e3b5dbe1ab4c388ce2d04c",
    "matched": false,
    "created_at": "2021-07-14T15:38:59.7710778+07:00"
}
```

> When user A like user B, A calls API with data in the body
if B liked A before,  `"match": true`,

else insert a new record in DB and response result
![image](https://user-images.githubusercontent.com/48717211/125591296-eb55147d-a41e-45e2-8c2d-64771b65db51.png)
  `"match": true`,
![image](https://user-images.githubusercontent.com/48717211/125591369-0e8b1808-aad5-4177-a603-90abd36aca2c.png)