### PR TITLE
DAT-34: BE - Enable/Disable account

### DIFF
--- a/internal/app/api/api.go
+++ b/internal/app/api/api.go
@@ -41,6 +41,7 @@ const (
 	post   = http.MethodPost
 	put    = http.MethodPut
 	delete = http.MethodDelete
+	patch  = http.MethodPatch
 )
 
 // Init init all handlers
@@ -122,6 +123,12 @@ func Init(conns *config.Configs, em config.ErrorMessage) (http.Handler, error) {
 			method:      get,
 			middlewares: []middlewareFunc{middleware.Auth},
 			handler:     userHandler.GetMatchedUsersByID,
+		},
+		route{
+			path:        "/users/{id:[a-z0-9-\\-]+}/disable",
+			method:      patch,
+			middlewares: []middlewareFunc{middleware.Auth},
+			handler:     userHandler.DisableUsersByID,
 		},
 	}
 

--- a/internal/app/api/handler/user/user.go
+++ b/internal/app/api/handler/user/user.go
@@ -22,6 +22,7 @@ type (
 		UpdateUserByID(ctx context.Context, User types.User) error
 		GetListUsers(ctx context.Context, page, size string) (*types.GetListUsersResponse, error)
 		GetMatchedUsersByID(ctx context.Context, idUser, matchedParameter string) ([]types.UserResGetInfo, error)
+		DisableUserByID(ctx context.Context, idUser, disableParameter string) error
 	}
 	// Handler is user web handler
 	Handler struct {
@@ -161,4 +162,16 @@ func (h *Handler) GetMatchedUsersByID(w http.ResponseWriter, r *http.Request) {
 	}
 
 	respond.JSON(w, http.StatusOK, list)
+}
+func (h *Handler) DisableUsersByID(w http.ResponseWriter, r *http.Request) {
+
+	userID := mux.Vars(r)["id"]
+	disableParameter := r.URL.Query().Get("disable")
+
+	if err := h.srv.DisableUserByID(r.Context(), userID, disableParameter); err != nil {
+		respond.JSON(w, http.StatusBadRequest, h.em.InvalidValue.Request)
+		return
+	}
+
+	respond.JSON(w, http.StatusOK, h.em.Success)
 }

--- a/internal/app/api/repositories/user/user_repo.go
+++ b/internal/app/api/repositories/user/user_repo.go
@@ -88,12 +88,10 @@ func (r *MongoRepository) DisableUserByID(ctx context.Context, idUser string, di
 	disableUpdate := bson.M{"$set": bson.M{
 		"disable": disable,
 	}}
-	err := r.collection(s).UpdateId(bson.ObjectIdHex(idUser), disableUpdate)
-
-	return err
+	return r.collection(s).UpdateId(bson.ObjectIdHex(idUser), disableUpdate)
 }
 
-// his method helps get all user by page
+// This method helps get all user by page
 func (r *MongoRepository) GetListUsers(ctx context.Context, ps types.PagingNSorting) ([]*types.UserResGetInfo, error) {
 	s := r.session.Clone()
 	defer s.Close()

--- a/internal/app/api/repositories/user/user_repo.go
+++ b/internal/app/api/repositories/user/user_repo.go
@@ -41,7 +41,7 @@ func (r *MongoRepository) FindByEmail(ctx context.Context, email string) (*types
 	defer s.Close()
 
 	var user *types.User
-	err := r.collection(s).Find(bson.M{"email": email}).One(&user)
+	err := r.collection(s).Find(bson.M{"email": email, "disable": false}).One(&user)
 
 	return user, err
 }
@@ -52,7 +52,7 @@ func (r *MongoRepository) FindByID(ctx context.Context, id string) (*types.UserR
 	defer s.Close()
 
 	var user *types.UserResGetInfo
-	err := r.collection(s).FindId(bson.ObjectIdHex(id)).One(&user)
+	err := r.collection(s).Find(bson.M{"_id": bson.ObjectIdHex(id), "disable": false}).One(&user)
 
 	return user, err
 }
@@ -80,13 +80,28 @@ func (r *MongoRepository) UpdateUserByID(ctx context.Context, user types.User) e
 	return err
 }
 
-// This method helps get all user by page
+// This method helps Enable/Disable account
+func (r *MongoRepository) DisableUserByID(ctx context.Context, idUser string, disable bool) error {
+	s := r.session.Clone()
+	defer s.Close()
+
+	disableUpdate := bson.M{"$set": bson.M{
+		"disable": disable,
+	}}
+	err := r.collection(s).UpdateId(bson.ObjectIdHex(idUser), disableUpdate)
+
+	return err
+}
+
+// his method helps get all user by page
 func (r *MongoRepository) GetListUsers(ctx context.Context, ps types.PagingNSorting) ([]*types.UserResGetInfo, error) {
 	s := r.session.Clone()
 	defer s.Close()
 
 	var result []*types.UserResGetInfo
-	err := r.collection(s).Find(nil).Skip((ps.Page - 1) * ps.Size).Limit(ps.Size).All(&result)
+	err := r.collection(s).Find(bson.M{
+		"disable": false,
+	}).Skip((ps.Page - 1) * ps.Size).Limit(ps.Size).All(&result)
 
 	return result, err
 }
@@ -96,7 +111,9 @@ func (r *MongoRepository) CountUser(ctx context.Context) (int, error) {
 	s := r.session.Clone()
 	defer s.Close()
 
-	number, err := r.collection(s).Count()
+	number, err := r.collection(s).Find(bson.M{
+		"disable": false,
+	}).Count()
 
 	return number, err
 }
@@ -130,6 +147,9 @@ func (r *MongoRepository) GetListMatchedInfo(ctx context.Context, idUser string)
 		}},
 		{"$unwind": "$target_user"},
 		{"$replaceRoot": bson.M{"newRoot": "$target_user"}},
+		{"$match": bson.M{
+			"disable": false,
+		}},
 	}
 	var listMatched []*types.UserResGetInfo
 	err := s.DB("").C("matches").Pipe(query).All(&listMatched)
@@ -156,6 +176,9 @@ func (r *MongoRepository) GetListlikedInfo(ctx context.Context, idUser string) (
 		}},
 		{"$unwind": "$target_user"},
 		{"$replaceRoot": bson.M{"newRoot": "$target_user"}},
+		{"$match": bson.M{
+			"disable": false,
+		}},
 	}
 
 	var listMatched []*types.UserResGetInfo

--- a/internal/app/api/services/user/user.go
+++ b/internal/app/api/services/user/user.go
@@ -259,13 +259,13 @@ func (s *Service) DisableUserByID(ctx context.Context, idUser string, disable bo
 		return errors.New("Id user incorrect to find list liked from database, it isn't ObjectIdHex")
 	}
 
-	disableStr := strconv.FormatBool(disable)
+	// disableStr := strconv.FormatBool(disable)
 	if err := s.repo.DisableUserByID(ctx, idUser, disable); err != nil {
-		s.logger.Errorf("Set disable to "+disableStr+" for user "+idUser+" failed", err)
+		s.logger.Errorf("Set disable to %d for user %s failed", disable, idUser, err)
 		return err
 	}
 
-	s.logger.Infof("Set disable to "+disableStr+" for user "+idUser+" completed", idUser)
+	s.logger.Infof("Set disable to %d for user %s completed", disable, idUser)
 	return nil
 
 }

--- a/internal/app/api/services/user/user.go
+++ b/internal/app/api/services/user/user.go
@@ -252,14 +252,7 @@ func (s *Service) convertPointerArrayToArray(list []*types.UserResGetInfo) []typ
 }
 
 // helps Enable/Disable account
-func (s *Service) DisableUserByID(ctx context.Context, idUser, disableParameter string) error {
-
-	disable, err := strconv.ParseBool(disableParameter)
-
-	if err != nil {
-		s.logger.Errorf("Failed url parameters when get list matched or like", err)
-		return errors.Wrap(err, "Failed url parameters when get list users")
-	}
+func (s *Service) DisableUserByID(ctx context.Context, idUser string, disable bool) error {
 
 	if !bson.IsObjectIdHex(idUser) {
 		s.logger.Errorf("Id user incorrect,it isn't ObjectIdHex")
@@ -272,12 +265,12 @@ func (s *Service) DisableUserByID(ctx context.Context, idUser, disableParameter 
 		}
 		s.logger.Infof("Disable completed", idUser)
 
-		return err
+		return nil
 	}
 
-	if err = s.repo.DisableUserByID(ctx, idUser, disable); err != nil {
+	if err := s.repo.DisableUserByID(ctx, idUser, disable); err != nil {
 		s.logger.Errorf("Enable failed", err)
 	}
 	s.logger.Infof("Enable completed", idUser)
-	return err
+	return nil
 }

--- a/internal/app/api/services/user/user.go
+++ b/internal/app/api/services/user/user.go
@@ -259,18 +259,13 @@ func (s *Service) DisableUserByID(ctx context.Context, idUser string, disable bo
 		return errors.New("Id user incorrect to find list liked from database, it isn't ObjectIdHex")
 	}
 
-	if disable {
-		if err := s.repo.DisableUserByID(ctx, idUser, disable); err != nil {
-			s.logger.Errorf("Disable failed", err)
-		}
-		s.logger.Infof("Disable completed", idUser)
-
-		return nil
-	}
-
+	disableStr := strconv.FormatBool(disable)
 	if err := s.repo.DisableUserByID(ctx, idUser, disable); err != nil {
-		s.logger.Errorf("Enable failed", err)
+		s.logger.Errorf("Set disable to "+disableStr+" for user "+idUser+" failed", err)
+		return err
 	}
-	s.logger.Infof("Enable completed", idUser)
+
+	s.logger.Infof("Set disable to "+disableStr+" for user "+idUser+" completed", idUser)
 	return nil
+
 }

--- a/internal/app/api/types/user.go
+++ b/internal/app/api/types/user.go
@@ -66,3 +66,7 @@ type UserLogin struct {
 	Email    string `json:"email" bson:"email" validate:"required,email"`
 	Password string `json:"password" bson:"password" validate:"required"`
 }
+
+type DisableBody struct {
+	Disable *bool `json:"disable" bson:"disable" validate:"required"`
+}

--- a/internal/app/api/types/user.go
+++ b/internal/app/api/types/user.go
@@ -19,6 +19,7 @@ type User struct {
 	Sex          string        `json:"sex" bson:"sex" validate:"omitempty,max=60"`
 	Country      string        `json:"country" bson:"country" validate:"required,max=60"`
 	Hobby        []string      `json:"hobby" bson:"hobby"`
+	Disable      bool          `json:"disable" bson:"disable"`
 	About        string        `json:"about" bson:"about" validate:"omitempty,max=256"`
 	CreateAt     time.Time     `json:"created_at" bson:"created_at"`
 	UpdateAt     time.Time     `json:"updated_at" bson:"updated_at"`


### PR DESCRIPTION
API patch : _`/users/{id:[a-z0-9-\\-]+}/disable`_ Required token in the header

Structure of body
```
{
  "disable": false
}
```
```
disable: true - Disable account
disable: false - Enable account
```
Structure of the result if successful: 
```
{
    "code": "01",
    "message": "OK"
}
```
**disable: true - Disable account**
![image](https://user-images.githubusercontent.com/48717211/126094587-eebb6591-b3e3-44c2-9018-7b5ef69241d7.png)

**disable: false - Enable account**
![image](https://user-images.githubusercontent.com/48717211/126094561-ffa66b4b-6b77-471e-a931-fb9c6115db56.png)

