### PR TITLE
Dat 97:  BE - Update chat

### DIFF
--- a/internal/app/api/handler/message/message.go
+++ b/internal/app/api/handler/message/message.go
@@ -16,7 +16,7 @@ import (
 
 type (
 	service interface {
-		ServeWs(wsServer *socket.WsServer, conn *websocket.Conn, idRoom string)
+		ServeWs(wsServer *socket.WsServer, conn *websocket.Conn, idRoom, idUser string)
 		GetMessagesByIdRoom(ctx context.Context, id string) ([]types.Message, error)
 	}
 	// Handler is message web handler
@@ -58,7 +58,8 @@ func New(c *config.Configs, e *config.ErrorMessage, s service, l glog.Logger) *H
 
 // Put handler server message socket HTTP request
 func (h *Handler) ServeWs(w http.ResponseWriter, r *http.Request) {
-	idRoom := r.URL.Query().Get("id")
+	idRoom := r.URL.Query().Get("room")
+	idUser := r.URL.Query().Get("user")
 	conn, err := upgrader.Upgrade(w, r, nil)
 
 	if err != nil {
@@ -66,7 +67,7 @@ func (h *Handler) ServeWs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	h.srv.ServeWs(wsServer, conn, idRoom)
+	h.srv.ServeWs(wsServer, conn, idRoom, idUser)
 
 	h.logger.Infof("New Client joined the room!" + idRoom)
 }

--- a/internal/app/api/repositories/message/message.go
+++ b/internal/app/api/repositories/message/message.go
@@ -60,5 +60,5 @@ func (r *MongoRepository) FindByIDRoom(ctx context.Context, id string) ([]*types
 }
 
 func (r *MongoRepository) collection() *mongo.Collection {
-	return r.client.Database("dating").Collection("message_test")
+	return r.client.Database("dating").Collection("messages")
 }

--- a/internal/app/api/repositories/message/message.go
+++ b/internal/app/api/repositories/message/message.go
@@ -60,5 +60,5 @@ func (r *MongoRepository) FindByIDRoom(ctx context.Context, id string) ([]*types
 }
 
 func (r *MongoRepository) collection() *mongo.Collection {
-	return r.client.Database("dating").Collection("message")
+	return r.client.Database("dating").Collection("message_test")
 }

--- a/internal/app/api/services/message/message.go
+++ b/internal/app/api/services/message/message.go
@@ -2,7 +2,6 @@ package messageservices
 
 import (
 	"context"
-	"fmt"
 
 	"dating/internal/app/api/types"
 	"dating/internal/app/config"
@@ -50,13 +49,10 @@ func (s *Service) ServeWs(wsServer *socket.WsServer, conn *websocket.Conn, idRoo
 	}
 
 	idUserHex, error := primitive.ObjectIDFromHex(idUser)
-
 	if error != nil {
 		s.logger.Errorf("Id user incorrect,it isn't ObjectIdHex %v", error)
 		return
 	}
-
-	fmt.Println(idRoomHex, idUserHex)
 
 	client := socket.NewClient(conn, wsServer, idRoomHex, idUserHex, saveMessagesChan)
 

--- a/internal/app/api/services/message/message.go
+++ b/internal/app/api/services/message/message.go
@@ -2,6 +2,7 @@ package messageservices
 
 import (
 	"context"
+	"fmt"
 
 	"dating/internal/app/api/types"
 	"dating/internal/app/config"
@@ -38,17 +39,26 @@ func NewService(c *config.Configs, e *config.ErrorMessage, r Repository, l glog.
 }
 
 // method help join client into room message server
-func (s *Service) ServeWs(wsServer *socket.WsServer, conn *websocket.Conn, idRoom string) {
+func (s *Service) ServeWs(wsServer *socket.WsServer, conn *websocket.Conn, idRoom, idUser string) {
 
 	saveMessagesChan := socket.NewSaveMessageChan(s.repo)
 	idRoomHex, error := primitive.ObjectIDFromHex(idRoom)
 
 	if error != nil {
-		s.logger.Errorf("Id room incorrect,it isn't ObjectIdHex ", error)
+		s.logger.Errorf("Id room incorrect,it isn't ObjectIdHex %v", error)
 		return
 	}
 
-	client := socket.NewClient(conn, wsServer, idRoomHex, saveMessagesChan)
+	idUserHex, error := primitive.ObjectIDFromHex(idUser)
+
+	if error != nil {
+		s.logger.Errorf("Id user incorrect,it isn't ObjectIdHex %v", error)
+		return
+	}
+
+	fmt.Println(idRoomHex, idUserHex)
+
+	client := socket.NewClient(conn, wsServer, idRoomHex, idUserHex, saveMessagesChan)
 
 	go client.Write(s.logger)
 	go client.Read(s.logger)

--- a/internal/app/api/types/message.go
+++ b/internal/app/api/types/message.go
@@ -10,6 +10,7 @@ type Message struct {
 	ID          primitive.ObjectID `json:"_id" bson:"_id,omitempty"`
 	RoomID      primitive.ObjectID `json:"room_id" bson:"room_id"`
 	SenderID    primitive.ObjectID `json:"sender_id" bson:"sender_id"`
+	ReceiverID  primitive.ObjectID `json:"receiver_id" bson:"receiver_id"`
 	Content     string             `json:"content" bson:"content"`
 	Attachments []string           `json:"attachments" bson:"attachments"`
 	CreateAt    time.Time          `json:"created_at" bson:"created_at"`

--- a/internal/pkg/socket/message.go
+++ b/internal/pkg/socket/message.go
@@ -25,8 +25,7 @@ func saveMessages(sm *chan SaveMessage, r Repository) {
 		}
 		err := r.Insert(context.Background(), *sm.message)
 		if err != nil {
-			logger.Errorf("Error when insert message to db", err)
-
+			logger.Errorf("Error when insert message to db %v", err)
 		}
 	}
 }

--- a/internal/pkg/socket/messageSocket.go
+++ b/internal/pkg/socket/messageSocket.go
@@ -6,7 +6,13 @@ const SendMessageAction = "send-message"
 const JoinRoomAction = "join-room"
 const LeaveRoomAction = "leave-room"
 
+var (
+	DoneMessage  = "done"
+	ErrorMessage = "error"
+)
+
 type MessageSocket struct {
 	Action string `json:"action"`
+	Status string `json:"status"`
 	types.Message
 }

--- a/internal/pkg/socket/roomSocket.go
+++ b/internal/pkg/socket/roomSocket.go
@@ -25,6 +25,12 @@ func NewRoom(id primitive.ObjectID, private bool) *RoomSocket {
 	}
 }
 
+// id for Room Big
+func IdBigRoom() primitive.ObjectID {
+	roomHex, _ := primitive.ObjectIDFromHex("000000000000000000000000")
+	return roomHex
+}
+
 // RunRoom runs our room, accepting various requests
 func (room *RoomSocket) RunRoomSocket() {
 	for {
@@ -54,6 +60,16 @@ func (room *RoomSocket) unregisterClientInRoom(client *Client) {
 }
 
 func (room *RoomSocket) broadcastToClientsInRoom(message *MessageSocket) {
+
+	if room.ID == IdBigRoom() {
+		for client := range room.clients {
+			if client.UserID == message.ReceiverID {
+				client.send <- message
+			}
+		}
+		return
+	}
+
 	for client := range room.clients {
 		client.send <- message
 	}

--- a/internal/pkg/socket/roomSocket.go
+++ b/internal/pkg/socket/roomSocket.go
@@ -4,6 +4,10 @@ import (
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
+var (
+	IdBigRoomStr = "000000000000000000000000"
+)
+
 type RoomSocket struct {
 	ID         primitive.ObjectID `json:"id"`
 	clients    map[*Client]bool
@@ -27,7 +31,7 @@ func NewRoom(id primitive.ObjectID, private bool) *RoomSocket {
 
 // id for Room Big
 func IdBigRoom() primitive.ObjectID {
-	roomHex, _ := primitive.ObjectIDFromHex("000000000000000000000000")
+	roomHex, _ := primitive.ObjectIDFromHex(IdBigRoomStr)
 	return roomHex
 }
 


### PR DESCRIPTION
Server websocket: `/ws?room={room_id}&user={user_id}"`

`Room big id = 000000000000000000000000`

ex: `ws://localhost:8080/ws?room=000000000000000000000000&user=60e3f9a7e1ab4c3dfc8fe4c1`

When a user uses the app: 
first, join the big room with id(000000000000000000000000) for receives messages to update the last message in the list chat inbox

when chatting with other users, join room with id is matched id.

![image](https://user-images.githubusercontent.com/48717211/128141090-72fc1915-cd00-43bf-86f9-3410fe403e08.png)

When chatting with other users, the message is also automatically sent to the main room (000000000000000000000000), only sent to the receiving user.

user 1 sent one message to user 2: 

![image](https://user-images.githubusercontent.com/48717211/128142007-e15887c2-6718-421c-9054-49b3cfea8c9e.png)

user 2 receive one message from user 1, and in big room too receive : 

![image](https://user-images.githubusercontent.com/48717211/128142342-f3880f60-3343-4e12-a08a-dce232671a3a.png)
![image](https://user-images.githubusercontent.com/48717211/128142532-7a94d672-f45b-4dee-9929-23fba4630869.png)

user 3  in big room, but not receive: 
![image](https://user-images.githubusercontent.com/48717211/128142684-16892816-d2fb-4ccf-bc68-d02c6fbde102.png)

When the user sent a message to socket, which is not struct valid. room sent a message err:
```
{
    status: "error",
    content: error description ,
    ...
}
```
When message sent successfully: 
```
{
    status: "done",
    ...
}
```
example: 
Error:
attachments: must a array string
![image](https://user-images.githubusercontent.com/48717211/128289610-1170c007-0733-47a6-8fb7-14af31203a3a.png)
![image](https://user-images.githubusercontent.com/48717211/128289661-df92f2f8-c06d-4c8a-8339-ef4b29a823c6.png)

Done:
![image](https://user-images.githubusercontent.com/48717211/128289693-95ef6993-7428-46cf-94f3-20d1ad515c60.png)
![image](https://user-images.githubusercontent.com/48717211/128289726-65fed143-5719-452a-b52d-2ec3b409561b.png)
